### PR TITLE
Added state switching

### DIFF
--- a/macha/src/compute_shader_test/mod.rs
+++ b/macha/src/compute_shader_test/mod.rs
@@ -126,6 +126,8 @@ impl ApplicationState for CSTState {
             schedule.add_systems(mesh_renderer::render_meshes::<Vertex>);
         });
 
+        let res = context.renderer.window_resolution();
+        self.camera.on_resize(res.0, res.1);
         context.ecs_manager.world.insert_resource(self.camera);
 
         let mut transform = Transform::default();

--- a/macha/src/editor/mod.rs
+++ b/macha/src/editor/mod.rs
@@ -144,48 +144,6 @@ impl BuildableApplicationState<()> for MachaState {
         )
         .expect("Failed to create mesh rendering");
 
-        let mut transform = Transform::default();
-        transform.rotate(&Quat::from_euler(
-            EulerRot::XYZ,
-            f32::to_radians(-90.0),
-            0.0,
-            0.0,
-        ));
-
-        camera.set_focal_point(transform.translation());
-
-        context.ecs_manager.world.insert_resource(ECSBuffer::new());
-        context
-            .ecs_manager
-            .world
-            .insert_resource(MachaGlobalOptions::new());
-
-        context.ecs_manager.world.spawn((
-            transform.clone(),
-            mesh_rendering_ref.clone(),
-            MachaEntityOptions {
-                name: "planet".to_owned(),
-            },
-        ));
-
-        context.ecs_manager.world.spawn((
-            transform,
-            MachaEntityOptions {
-                name: "empty".to_owned(),
-            },
-        ));
-
-        context.ecs_manager.redefine_systems_schedule(|schedule| {
-            schedule.add_systems(mesh_renderer::render_meshes::<Vertex>);
-        });
-
-        context
-            .ecs_manager
-            .redefine_ui_systems_schedule(|schedule| {
-                schedule.add_systems(hierarchy_panel::draw_hierarchy_panel_stable);
-                schedule.add_systems(gizmo_drawer::draw_gizmo);
-            });
-
         MachaState {
             camera,
             shader_ref,
@@ -203,6 +161,48 @@ impl BuildableApplicationState<()> for MachaState {
 
 impl ApplicationState for MachaState {
     fn on_attach(&mut self, context: &mut StateContext) {
+        context.ecs_manager.redefine_systems_schedule(|schedule| {
+            schedule.add_systems(mesh_renderer::render_meshes::<Vertex>);
+        });
+
+        let mut transform = Transform::default();
+        transform.rotate(&Quat::from_euler(
+            EulerRot::XYZ,
+            f32::to_radians(-90.0),
+            0.0,
+            0.0,
+        ));
+
+        self.camera.set_focal_point(transform.translation());
+
+        context.ecs_manager.world.insert_resource(ECSBuffer::new());
+        context
+            .ecs_manager
+            .world
+            .insert_resource(MachaGlobalOptions::new());
+
+        context.ecs_manager.world.spawn((
+            transform.clone(),
+            self.mesh_rendering_ref.clone(),
+            MachaEntityOptions {
+                name: "planet".to_owned(),
+            },
+        ));
+
+        context.ecs_manager.world.spawn((
+            transform,
+            MachaEntityOptions {
+                name: "empty".to_owned(),
+            },
+        ));
+
+        context
+            .ecs_manager
+            .redefine_ui_systems_schedule(|schedule| {
+                schedule.add_systems(hierarchy_panel::draw_hierarchy_panel_stable);
+                schedule.add_systems(gizmo_drawer::draw_gizmo);
+            });
+
         let selection_style = egui::style::Selection {
             bg_fill: egui::Color32::from_rgb(165, 20, 61),
             ..Default::default()

--- a/macha/src/editor/mod.rs
+++ b/macha/src/editor/mod.rs
@@ -270,15 +270,16 @@ impl ApplicationState for MachaState {
     }
 
     fn on_update(&mut self, dt: std::time::Duration, context: &mut StateContext) {
+        // https://github.com/urholaukkarinen/egui-gizmo/issues/29
         self.camera.on_update(dt, context.window_input_state);
         context
             .ecs_manager
             .world
-            .insert_resource(ResourceWrapper::new(context.window_input_state.clone()));
+            .insert_resource(self.camera.mrg_camera);
         context
             .ecs_manager
             .world
-            .insert_resource(self.camera.mrg_camera);
+            .insert_resource(ResourceWrapper::new(context.window_input_state.clone()));
     }
 
     fn on_update_egui(&mut self, dt: std::time::Duration, context: &mut EguiUpdateContext) {

--- a/macha/src/editor/mod.rs
+++ b/macha/src/editor/mod.rs
@@ -171,6 +171,9 @@ impl ApplicationState for MachaState {
             schedule.add_systems(mesh_renderer::render_meshes::<Vertex>);
         });
 
+        let res = context.renderer.window_resolution();
+        self.camera.on_resize(res.0, res.1);
+
         let mut transform = Transform::default();
         transform.rotate(&Quat::from_euler(
             EulerRot::XYZ,
@@ -178,7 +181,6 @@ impl ApplicationState for MachaState {
             0.0,
             0.0,
         ));
-
         self.camera.set_focal_point(transform.translation());
 
         context.ecs_manager.world.insert_resource(ECSBuffer::new());

--- a/macha/src/editor/mod.rs
+++ b/macha/src/editor/mod.rs
@@ -2,7 +2,7 @@ mod components;
 mod ecs_buffer;
 mod systems;
 
-use crate::utils::switcher::{draw_state_switcher, SwitchableStates};
+use crate::utils::ui::{draw_debug_utils, draw_state_switcher, SwitchableStates};
 
 use super::utils::camera::MachaCamera;
 use bevy_ecs::prelude::Entity;
@@ -231,22 +231,40 @@ impl ApplicationState for MachaState {
         self.egui_texture_id = context.egui.painter.register_user_texture(egui_texture);
     }
 
-    fn flow<'flow>(
-        &mut self,
-        context: &mut morrigu::application::StateContext,
-    ) -> morrigu::application::StateFlow<'flow> {
-        match self.desired_state {
-            SwitchableStates::GLTFLoader => morrigu::application::StateFlow::SwitchState(Box::new(
-                crate::gltf_loader::GLTFViewerState::build(context, ()),
-            )),
-            SwitchableStates::CSTest => morrigu::application::StateFlow::SwitchState(Box::new(
-                crate::compute_shader_test::CSTState::build(context, ()),
-            )),
-            SwitchableStates::RTTest => morrigu::application::StateFlow::SwitchState(Box::new(
-                crate::rt_test::RayTracerState::build(context, ()),
-            )),
-            SwitchableStates::Editor => morrigu::application::StateFlow::Continue,
+    fn on_drop(&mut self, context: &mut StateContext) {
+        if let Some(texture) = context
+            .egui
+            .painter
+            .retrieve_user_texture(self.egui_texture_id)
+        {
+            texture.lock().destroy(context.renderer);
         }
+
+        self.mesh_rendering_ref
+            .lock()
+            .descriptor_resources
+            .uniform_buffers
+            .get(&0)
+            .unwrap()
+            .lock()
+            .destroy(&context.renderer.device, &mut context.renderer.allocator());
+
+        self.mesh_rendering_ref
+            .lock()
+            .descriptor_resources
+            .uniform_buffers
+            .get(&4)
+            .unwrap()
+            .lock()
+            .destroy(&context.renderer.device, &mut context.renderer.allocator());
+
+        self.gradient_ref.lock().destroy(context.renderer);
+        self.flowmap_ref.lock().destroy(context.renderer);
+        self.texture_ref.lock().destroy(context.renderer);
+        self.mesh_rendering_ref.lock().destroy(context.renderer);
+        self.mesh_ref.lock().destroy(context.renderer);
+        self.material_ref.lock().destroy(context.renderer);
+        self.shader_ref.lock().destroy(&context.renderer.device);
     }
 
     fn on_update(&mut self, dt: std::time::Duration, context: &mut StateContext) {
@@ -263,17 +281,8 @@ impl ApplicationState for MachaState {
 
     fn on_update_egui(&mut self, dt: std::time::Duration, context: &mut EguiUpdateContext) {
         draw_state_switcher(context.egui_context, &mut self.desired_state);
-        egui::Window::new("Debug info").show(context.egui_context, |ui| {
-            let color = match dt.as_millis() {
-                0..=25 => [51, 204, 51],
-                26..=50 => [255, 153, 0],
-                _ => [204, 51, 51],
-            };
-            ui.colored_label(
-                egui::Color32::from_rgb(color[0], color[1], color[2]),
-                format!("FPS: {} ({}ms)", 1.0 / dt.as_secs_f32(), dt.as_millis()),
-            );
-        });
+        draw_debug_utils(context.egui_context, dt);
+
         egui::Window::new("Shader uniforms").show(context.egui_context, |ui| {
             let image = egui::ImageSource::Texture(
                 (self.egui_texture_id, egui::Vec2::new(128.0, 128.0)).into(),
@@ -355,40 +364,22 @@ impl ApplicationState for MachaState {
         }
     }
 
-    fn on_drop(&mut self, context: &mut StateContext) {
-        if let Some(texture) = context
-            .egui
-            .painter
-            .retrieve_user_texture(self.egui_texture_id)
-        {
-            texture.lock().destroy(context.renderer);
+    fn flow<'flow>(
+        &mut self,
+        context: &mut StateContext,
+    ) -> morrigu::application::StateFlow<'flow> {
+        match self.desired_state {
+            SwitchableStates::GLTFLoader => morrigu::application::StateFlow::SwitchState(Box::new(
+                crate::gltf_loader::GLTFViewerState::build(context, ()),
+            )),
+            SwitchableStates::CSTest => morrigu::application::StateFlow::SwitchState(Box::new(
+                crate::compute_shader_test::CSTState::build(context, ()),
+            )),
+            SwitchableStates::RTTest => morrigu::application::StateFlow::SwitchState(Box::new(
+                crate::rt_test::RayTracerState::build(context, ()),
+            )),
+            SwitchableStates::Editor => morrigu::application::StateFlow::Continue,
         }
-
-        self.mesh_rendering_ref
-            .lock()
-            .descriptor_resources
-            .uniform_buffers
-            .get(&0)
-            .unwrap()
-            .lock()
-            .destroy(&context.renderer.device, &mut context.renderer.allocator());
-
-        self.mesh_rendering_ref
-            .lock()
-            .descriptor_resources
-            .uniform_buffers
-            .get(&4)
-            .unwrap()
-            .lock()
-            .destroy(&context.renderer.device, &mut context.renderer.allocator());
-
-        self.gradient_ref.lock().destroy(context.renderer);
-        self.flowmap_ref.lock().destroy(context.renderer);
-        self.texture_ref.lock().destroy(context.renderer);
-        self.mesh_rendering_ref.lock().destroy(context.renderer);
-        self.mesh_ref.lock().destroy(context.renderer);
-        self.material_ref.lock().destroy(context.renderer);
-        self.shader_ref.lock().destroy(&context.renderer.device);
     }
 }
 

--- a/macha/src/gltf_loader/loader.rs
+++ b/macha/src/gltf_loader/loader.rs
@@ -189,7 +189,7 @@ pub fn load_gltf(
         .map(|image| {
             let image = image
                 .convert_format(gltf::image::Format::R8G8B8A8)
-                .context("Failed to convert GLTF image to RGAB8")?;
+                .context("Failed to convert GLTF image to RGBA8")?;
             Texture::builder()
                 .build_from_data(&image.pixels, image.width, image.height, renderer)
                 .context("Failed to create texture form GTLF data")

--- a/macha/src/gltf_loader/mod.rs
+++ b/macha/src/gltf_loader/mod.rs
@@ -180,6 +180,8 @@ impl ApplicationState for GLTFViewerState {
                 .spawn((transform.clone(), mesh_rendering_ref.clone()));
         }
 
+        let res = context.renderer.window_resolution();
+        self.camera.on_resize(res.0, res.1);
         self.skybox_entity_ref = context
             .ecs_manager
             .world

--- a/macha/src/main.rs
+++ b/macha/src/main.rs
@@ -37,12 +37,11 @@ fn init_logging() {
 fn main() {
     init_logging();
 
-    let mut application = ApplicationBuilder::new()
+    ApplicationBuilder::new()
         .with_window_name("Macha editor")
         .with_dimensions(1280, 720)
         .with_application_name("Macha")
         .with_application_version(0, 1, 0)
-        .build_with_state::<MachaState, ()>(());
-
-    application.run();
+        .build_with_state::<MachaState, ()>(())
+        .run();
 }

--- a/macha/src/main.rs
+++ b/macha/src/main.rs
@@ -5,15 +5,7 @@ mod editor;
 mod gltf_loader;
 mod rt_test;
 
-#[allow(unused_imports)]
-use compute_shader_test::CSTState;
-#[allow(unused_imports)]
 use editor::MachaState;
-#[allow(unused_imports)]
-use gltf_loader::GLTFViewerState;
-#[allow(unused_imports)]
-use rt_test::RayTracerState;
-
 use morrigu::application::ApplicationBuilder;
 
 fn init_logging() {

--- a/macha/src/main.rs
+++ b/macha/src/main.rs
@@ -37,10 +37,12 @@ fn init_logging() {
 fn main() {
     init_logging();
 
-    ApplicationBuilder::new()
+    let mut application = ApplicationBuilder::new()
         .with_window_name("Macha editor")
         .with_dimensions(1280, 720)
         .with_application_name("Macha")
         .with_application_version(0, 1, 0)
-        .build_and_run_inplace::<MachaState, ()>(());
+        .build_with_state::<MachaState, ()>(());
+
+    application.run();
 }

--- a/macha/src/rt_test/mod.rs
+++ b/macha/src/rt_test/mod.rs
@@ -3,7 +3,6 @@ use morrigu::{
     components::ray_tracing::{mesh_rendering::MeshRendering, tlas::TLAS},
     utils::ThreadSafeRef,
     vertices::simple::SimpleVertex,
-    winit,
 };
 
 pub struct RayTracerState {
@@ -48,41 +47,6 @@ impl BuildableApplicationState<()> for RayTracerState {
 
 impl ApplicationState for RayTracerState {
     fn on_attach(&mut self, _context: &mut morrigu::application::StateContext) {}
-
-    fn on_update(
-        &mut self,
-        _dt: std::time::Duration,
-        _context: &mut morrigu::application::StateContext,
-    ) {
-    }
-
-    fn after_systems(
-        &mut self,
-        _dt: std::time::Duration,
-        _context: &mut morrigu::application::StateContext,
-    ) {
-    }
-
-    fn on_update_egui(
-        &mut self,
-        _dt: std::time::Duration,
-        _context: &mut morrigu::application::EguiUpdateContext,
-    ) {
-    }
-
-    fn after_ui_systems(
-        &mut self,
-        _dt: std::time::Duration,
-        _context: &mut morrigu::application::EguiUpdateContext,
-    ) {
-    }
-
-    fn on_event(
-        &mut self,
-        _event: winit::event::Event<()>,
-        _context: &mut morrigu::application::StateContext,
-    ) {
-    }
 
     fn on_drop(&mut self, context: &mut morrigu::application::StateContext) {
         self.tlas.lock().destroy(context.renderer);

--- a/macha/src/rt_test/mod.rs
+++ b/macha/src/rt_test/mod.rs
@@ -5,7 +5,7 @@ use morrigu::{
     vertices::simple::SimpleVertex,
 };
 
-use crate::utils::switcher::{draw_state_switcher, SwitchableStates};
+use crate::utils::ui::{draw_state_switcher, SwitchableStates};
 
 pub struct RayTracerState {
     monkey_mr: ThreadSafeRef<MeshRendering<SimpleVertex>>,
@@ -71,6 +71,10 @@ impl ApplicationState for RayTracerState {
             .destroy(context.renderer);
     }
 
+    fn on_update_egui(&mut self, _dt: std::time::Duration, context: &mut EguiUpdateContext) {
+        draw_state_switcher(context.egui_context, &mut self.desired_state);
+    }
+
     fn flow<'flow>(
         &mut self,
         context: &mut morrigu::application::StateContext,
@@ -87,9 +91,5 @@ impl ApplicationState for RayTracerState {
             )),
             SwitchableStates::RTTest => morrigu::application::StateFlow::Continue,
         }
-    }
-
-    fn on_update_egui(&mut self, _dt: std::time::Duration, context: &mut EguiUpdateContext) {
-        draw_state_switcher(context.egui_context, &mut self.desired_state);
     }
 }

--- a/macha/src/utils/mod.rs
+++ b/macha/src/utils/mod.rs
@@ -1,3 +1,3 @@
 pub mod camera;
-pub mod switcher;
+pub mod ui;
 

--- a/macha/src/utils/mod.rs
+++ b/macha/src/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod camera;
+pub mod switcher;
 

--- a/macha/src/utils/switcher.rs
+++ b/macha/src/utils/switcher.rs
@@ -1,0 +1,37 @@
+use std::fmt::Display;
+
+use morrigu::egui;
+
+#[derive(PartialEq, Copy, Clone)]
+pub enum SwitchableStates {
+    Editor,
+    GLTFLoader,
+    CSTest,
+    RTTest,
+}
+
+impl Display for SwitchableStates {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            SwitchableStates::Editor => "Macha Editor",
+            SwitchableStates::GLTFLoader => "GLTF Loader and Viewer",
+            SwitchableStates::CSTest => "Compute Shader Test",
+            SwitchableStates::RTTest => "Ray Tracing Test",
+        };
+
+        write!(f, "{}", name)
+    }
+}
+
+pub fn draw_state_switcher(ctx: &egui::Context, current_state: &mut SwitchableStates) {
+    egui::Window::new("State Switcher").show(ctx, |ui| {
+        egui::ComboBox::from_label("Select desired state:")
+            .selected_text(format!("{current_state}"))
+            .show_ui(ui, |ui| {
+                ui.selectable_value(current_state, SwitchableStates::Editor, format!("{}", SwitchableStates::Editor));
+                ui.selectable_value(current_state, SwitchableStates::GLTFLoader, format!("{}", SwitchableStates::GLTFLoader));
+                ui.selectable_value(current_state, SwitchableStates::CSTest, format!("{}", SwitchableStates::CSTest));
+                ui.selectable_value(current_state, SwitchableStates::RTTest, format!("{}", SwitchableStates::RTTest));
+            });
+    });
+}

--- a/macha/src/utils/ui.rs
+++ b/macha/src/utils/ui.rs
@@ -35,3 +35,17 @@ pub fn draw_state_switcher(ctx: &egui::Context, current_state: &mut SwitchableSt
             });
     });
 }
+
+pub fn draw_debug_utils(ctx: &egui::Context, dt: std::time::Duration) {
+    egui::Window::new("Debug info").show(ctx, |ui| {
+        let color = match dt.as_millis() {
+            0..=25 => [51, 204, 51],
+            26..=50 => [255, 153, 0],
+            _ => [204, 51, 51],
+        };
+        ui.colored_label(
+            egui::Color32::from_rgb(color[0], color[1], color[2]),
+            format!("FPS: {} ({}ms)", 1.0 / dt.as_secs_f32(), dt.as_millis()),
+        );
+    });
+}

--- a/src/application.rs
+++ b/src/application.rs
@@ -193,21 +193,27 @@ impl<'state> Application<'state> {
                     StateFlow::Continue => (),
                     StateFlow::Exit => target.exit(),
                     StateFlow::SwitchState(new_state) => {
-                        log::info!("Switching states !");
+                        log::debug!("Switching states !");
 
                         self.state.on_drop(&mut state_context);
+
+                        let res = match self.window_input_state.resolution() {
+                            Some((x, y)) => (x, y),
+                            None => (
+                                self.window.inner_size().width,
+                                self.window.inner_size().height,
+                            ),
+                        };
                         let camera = Camera::builder().build(
                             Projection::Perspective(PerspectiveData {
                                 horizontal_fov: f32::to_radians(90.0),
                                 near_plane: 0.001,
                                 far_plane: 1000.0,
                             }),
-                            &Vec2::new(
-                                self.window.inner_size().width as f32,
-                                self.window.inner_size().height as f32,
-                            ),
+                            &Vec2::new(res.0 as f32, res.1 as f32),
                         );
                         *state_context.ecs_manager = ECSManager::new(&self.renderer_ref, camera);
+                        state_context.ecs_manager.on_resize(res.0, res.1);
 
                         self.state = new_state;
                         self.state.on_attach(&mut state_context);

--- a/src/application.rs
+++ b/src/application.rs
@@ -284,6 +284,7 @@ impl<'a> ApplicationBuilder<'a> {
         self
     }
 
+    #[must_use = "you are building an application, but doing nothing with it, consider calling `run` on the return value of this function"]
     pub fn build_with_state<'state, StateType, UserData>(
         self,
         data: UserData,

--- a/src/application.rs
+++ b/src/application.rs
@@ -52,10 +52,6 @@ pub trait ApplicationState {
     fn on_attach(&mut self, _context: &mut StateContext) {}
     fn on_drop(&mut self, _context: &mut StateContext) {}
 
-    fn flow<'flow>(&mut self, _context: &mut StateContext) -> StateFlow<'flow> {
-        StateFlow::Continue
-    }
-
     fn on_update(&mut self, _dt: Duration, _context: &mut StateContext) {}
     fn after_systems(&mut self, _dt: Duration, _context: &mut StateContext) {}
     #[cfg(feature = "egui")]
@@ -63,6 +59,10 @@ pub trait ApplicationState {
     #[cfg(feature = "egui")]
     fn after_ui_systems(&mut self, _dt: Duration, _context: &mut EguiUpdateContext) {}
     fn on_event(&mut self, _event: Event<()>, _context: &mut StateContext) {}
+
+    fn flow<'flow>(&mut self, _context: &mut StateContext) -> StateFlow<'flow> {
+        StateFlow::Continue
+    }
 }
 
 pub trait BuildableApplicationState<UserData>: ApplicationState {

--- a/src/components/camera.rs
+++ b/src/components/camera.rs
@@ -86,6 +86,19 @@ pub struct Camera {
     size: Vec2,
 }
 
+impl Default for Camera {
+    fn default() -> Self {
+        Self::builder().build(
+            Projection::Perspective(PerspectiveData {
+                horizontal_fov: f32::to_radians(90.0),
+                near_plane: 0.0001,
+                far_plane: 1000.0,
+            }),
+            &Vec2::new(1280.0, 720.0),
+        )
+    }
+}
+
 #[profiling::all_functions]
 impl Camera {
     #[profiling::skip]

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1020,6 +1020,10 @@ impl Renderer {
         self.default_texture_ref.clone()
     }
 
+    pub fn window_resolution(&self) -> (u32, u32) {
+        (self.window_width, self.window_height)
+    }
+
     pub(crate) fn begin_frame(&mut self) -> bool {
         if self.window_width == 0 || self.window_height == 0 {
             return false;


### PR DESCRIPTION
The application logic, and currently existing states were reworked to allow switching between them at runtime using the `StateFlow` enum.